### PR TITLE
iconOpacity Option & minZoomConstantScale

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,7 @@ Feel free to contribute
 
 ## Fork Differences
 Following features have been added for personal projects:
-
-* Ability to display permanent tooltips to use as labels
-* Better zooming animation
-* Icon shadow support
+Add support for Z-Index
 
 ## Demo
 

--- a/src/plugin/leaflet.canvas-markers.js
+++ b/src/plugin/leaflet.canvas-markers.js
@@ -24,7 +24,7 @@
             this._canvasSize = { x: 0, y: 0 };
         },
 
-        // @option minConstantScale: Number = true
+        // @option minZoomConstantScale: Number = true
 		// if the zoom is superior of minConstant Scale the icon will always be the normal size
 		
         setOptions: function(options) {
@@ -273,8 +273,8 @@
         _drawImage: function(marker, pointPos) {
             const iconOptions = marker.options.icon.options;
             var scaleReduction=1;
-            if (this.options.minConstantScale && this._map._zoom<this.options.minConstantScale){
-            	scaleReduction=Math.pow(2, this.options.minConstantScale-this._map._zoom);
+            if (this.options.minZoomConstantScale && this._map._zoom<this.options.minZoomConstantScale){
+            	scaleReduction=Math.pow(2, this.options.minZoomConstantScale-this._map._zoom);
             }
             if (!iconOptions.iconAnchor) {
                 iconOptions.iconAnchor = [0, 0];

--- a/src/plugin/leaflet.canvas-markers.js
+++ b/src/plugin/leaflet.canvas-markers.js
@@ -386,7 +386,11 @@
                 maxY: mapBounds.getNorth()
             };
 
-            self._latlngMarkers.search(mapBoxCoords).forEach(function(e) {
+            self._latlngMarkers.search(mapBoxCoords).sort(
+					function(a, b) {
+						return (a.data.zIndex > b.data.zIndex) ? 1
+								: ((b.data.zIndex > a.data.zIndex) ? -1 : 0);
+					}).forEach(function(e) {
                 //Readjust Point Map
                 var pointPos = self._map.latLngToContainerPoint(
                     e.data.getLatLng()

--- a/src/plugin/leaflet.canvas-markers.js
+++ b/src/plugin/leaflet.canvas-markers.js
@@ -24,6 +24,9 @@
             this._canvasSize = { x: 0, y: 0 };
         },
 
+        // @option minConstantScale: Number = true
+		// if the zoom is superior of minConstant Scale the icon will always be the normal size
+		
         setOptions: function(options) {
             L.setOptions(this, options);
             return this.redraw();
@@ -269,37 +272,42 @@
 
         _drawImage: function(marker, pointPos) {
             const iconOptions = marker.options.icon.options;
-
+            var scaleReduction=1;
+            if (this.options.minConstantScale && this._map._zoom<this.options.minConstantScale){
+            	scaleReduction=Math.pow(2, this.options.minConstantScale-this._map._zoom);
+            }
             if (!iconOptions.iconAnchor) {
                 iconOptions.iconAnchor = [0, 0];
             }
 
-            const xImage = pointPos.x - iconOptions.iconAnchor[0];
-            const yImage = pointPos.y - iconOptions.iconAnchor[1];
+            const xImage = pointPos.x - iconOptions.iconAnchor[0]/scaleReduction;
+            const yImage = pointPos.y - iconOptions.iconAnchor[1]/scaleReduction;
 
             if (this._debug) {
 
                 this._context.fillRect(
                     xImage ,
                     yImage ,
-                    iconOptions.iconSize[0],
-                    iconOptions.iconSize[1],
+                    iconOptions.iconSize[0]/scaleReduction,
+                    iconOptions.iconSize[1]/scaleReduction,
                 );
             }
-
+            if (typeof iconOptions.iconOpacity === "number"){
+            	this._context.globalAlpha = iconOptions.iconOpacity;
+            }
             this._context.drawImage(
                 marker._icon,
                 xImage,
                 yImage,
-                iconOptions.iconSize[0],
-                iconOptions.iconSize[1]
+                iconOptions.iconSize[0]/scaleReduction,
+                iconOptions.iconSize[1]/scaleReduction
             );
 
             if (marker.hasShadow) {
                 this._context.drawImage(
                     marker._shadowIcon,
-                    pointPos.x - iconOptions.shadowAnchor[0],
-                    pointPos.y - iconOptions.shadowAnchor[1],
+                    pointPos.x - iconOptions.shadowAnchor[0]/scaleReduction,
+                    pointPos.y - iconOptions.shadowAnchor[1]/scaleReduction,
                     iconOptions.shadowSize[0],
                     iconOptions.shadowSize[1]
                 );
@@ -313,16 +321,16 @@
 
                 switch (hasTooltip.options.direction) {
                     case "top":
-                        yDirectionOffset = -iconOptions.iconSize[1];
+                        yDirectionOffset = -iconOptions.iconSize[1]/scaleReduction;
                         break;
                     case "right":
-                        xDirectionOffset = iconOptions.iconSize[0];
+                        xDirectionOffset = iconOptions.iconSize[0]/scaleReduction;
                         break;
                     case "bottom":
-                        yDirectionOffset = iconOptions.iconSize[1];
+                        yDirectionOffset = iconOptions.iconSize[1]/scaleReduction;
                         break;
                     case "left":
-                        xDirectionOffset = -iconOptions.iconSize[0];
+                        xDirectionOffset = -iconOptions.iconSize[0]/scaleReduction;
                         break;
                 }
 

--- a/src/plugin/leaflet.canvas-markers.js
+++ b/src/plugin/leaflet.canvas-markers.js
@@ -471,29 +471,31 @@
             if (animated) {
                 var that = this;
                 this._map.on("zoomanim", function(e) {
-                    var scale = that._map.getZoomScale(e.zoom);
-                    // -- different calc of animation zoom  in leaflet 1.0.3 thanks @peterkarabinovic, @jduggan1
-                    var offset = L.Layer
-                        ? that._map._latLngBoundsToNewLayerBounds(
-                              that._map.getBounds(),
-                              e.zoom,
-                              e.center
-                          ).min
-                        : that._map
-                              ._getCenterOffset(e.center)
-                              ._multiplyBy(-scale)
-                              .subtract(that._map._getMapPanePos());
+					if (that._map!=null){
+						var scale = that._map.getZoomScale(e.zoom);
+						// -- different calc of animation zoom  in leaflet 1.0.3 thanks @peterkarabinovic, @jduggan1
+						var offset = L.Layer
+							? that._map._latLngBoundsToNewLayerBounds(
+								  that._map.getBounds(),
+								  e.zoom,
+								  e.center
+							  ).min
+							: that._map
+								  ._getCenterOffset(e.center)
+								  ._multiplyBy(-scale)
+								  .subtract(that._map._getMapPanePos());
 
-                    var pos = offset || new L.Point(0, 0);
+						var pos = offset || new L.Point(0, 0);
 
-                    that._canvas.style[L.DomUtil.TRANSFORM] =
-                        (L.Browser.ie3d
-                            ? "translate(" + pos.x + "px," + pos.y + "px)"
-                            : "translate3d(" +
-                              pos.x +
-                              "px," +
-                              pos.y +
-                              "px,0)") + (scale ? " scale(" + scale + ")" : "");
+						that._canvas.style[L.DomUtil.TRANSFORM] =
+							(L.Browser.ie3d
+								? "translate(" + pos.x + "px," + pos.y + "px)"
+								: "translate3d(" +
+								  pos.x +
+								  "px," +
+								  pos.y +
+								  "px,0)") + (scale ? " scale(" + scale + ")" : "");
+						}
                 });
             }
         },

--- a/src/plugin/leaflet.canvas-markers.js
+++ b/src/plugin/leaflet.canvas-markers.js
@@ -177,15 +177,21 @@
 
             var pointPos = self._map.latLngToContainerPoint(latlng);
             var iconSize = marker.options.icon.options.iconSize;
+			const iconOptions = marker.options.icon.options;
 
-            var adj_x = iconSize[0] / 2;
-            var adj_y = iconSize[1] / 2;
+            if (!iconOptions.iconAnchor) {
+                iconOptions.iconAnchor = [0, 0];
+            }
+
+            const xImage = pointPos.x - iconOptions.iconAnchor[0];
+            const yImage = pointPos.y - iconOptions.iconAnchor[1];
+
             var ret = [
                 {
-                    minX: pointPos.x - adj_x,
-                    minY: pointPos.y - adj_y,
-                    maxX: pointPos.x + adj_x,
-                    maxY: pointPos.y + adj_y,
+                    minX: xImage ,
+                    minY: yImage ,
+                    maxX: xImage +  iconSize[0],
+                    maxY: yImage +  iconSize[1],
                     data: marker
                 },
                 {
@@ -272,14 +278,12 @@
             const yImage = pointPos.y - iconOptions.iconAnchor[1];
 
             if (this._debug) {
-                const adj_x = iconOptions.iconSize[0] / 2;
-                const adj_y = iconOptions.iconSize[1] / 2;
 
                 this._context.fillRect(
-                    pointPos.x - adj_x,
-                    pointPos.y - adj_y,
-                    2 * adj_x,
-                    2 * adj_y
+                    xImage ,
+                    yImage ,
+                    iconOptions.iconSize[0],
+                    iconOptions.iconSize[1],
                 );
             }
 
@@ -399,12 +403,20 @@
                 var iconSize = e.data.options.icon.options.iconSize;
                 var adj_x = iconSize[0] / 2;
                 var adj_y = iconSize[1] / 2;
+				const iconOptions = e.data.options.icon.options;
+
+                if (!iconOptions.iconAnchor) {
+                    iconOptions.iconAnchor = [0, 0];
+                }
+
+                const xImage = pointPos.x - iconOptions.iconAnchor[0];
+                const yImage = pointPos.y - iconOptions.iconAnchor[1];
 
                 var newCoords = {
-                    minX: pointPos.x - adj_x,
-                    minY: pointPos.y - adj_y,
-                    maxX: pointPos.x + adj_x,
-                    maxY: pointPos.y + adj_y,
+                    minX: xImage ,
+                    minY: yImage ,
+                    maxX: xImage +  iconSize[0],
+                    maxY: yImage +  iconSize[1],
                     data: e.data
                 };
 


### PR DESCRIPTION
option to define the opacity of each marker

minZoomConstantScale allow to show the marker at a constant size if the Zoom is superior at this value and scale down when the zoom is inferior at this value. If this option is not specified, the Icon will keep it s constant size all the time